### PR TITLE
Add FrameParser class

### DIFF
--- a/tests/consts.py
+++ b/tests/consts.py
@@ -13,3 +13,11 @@ FAST_BUTTON_FRAMES = [
     *[{"Button0": 0}] * 2,
     *[{"Button0": 1}] * 2,
 ]
+
+FRAME_PARSER_FRAMES = [
+    {"Button0": 0, "Axis1": 0, "Axis2": 0},
+    {"Button0": 1, "Axis1": 0.5, "Axis2": 0},
+    {"Button0": 1, "Axis1": 1, "Axis2": 1},
+]
+
+COMBINE_AXES_DICT = {"Joystick1": ("Axis1", "Axis2")}

--- a/tests/test_event_gen.py
+++ b/tests/test_event_gen.py
@@ -24,3 +24,21 @@ def test_sequential_event_gen():
         poller.SequentialMockPoller(consts.SIMPLE_BUTTON_FRAMES, loop=True)
     )
     assert list(itertools.islice(iter(gen), 4)) == [("Button0", 1), ("Button0", 0)] * 2
+
+
+def test_frame_parser_event_gen():
+    """
+    Tests to make sure that an EventGenerator based on a FrameParser produces
+    the appropriate events.
+    """
+    gen = event_gen.EventGenerator(
+        poller.FrameParser(
+            poller.SequentialMockPoller(consts.FRAME_PARSER_FRAMES),
+            consts.COMBINE_AXES_DICT,
+        )
+    )
+    assert list(iter(gen)) == [
+        ("Joystick1", (0.5, 0)),
+        ("Button0", 1),
+        ("Joystick1", (1, 1)),
+    ]

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -28,3 +28,29 @@ def test_sequential_poller():
         list(itertools.islice(p, poller.DEVICE_HZ * 2))
         == consts.SIMPLE_BUTTON_FRAMES * 2
     )
+
+
+def test_parse_frame():
+    """
+    Tests to make sure that parse_frame can parse a single frame.
+    """
+    assert poller.parse_frame(
+        consts.COMBINE_AXES_DICT, consts.FRAME_PARSER_FRAMES[0]
+    ) == {"Button0": 0, "Joystick1": (0, 0)}
+
+
+def test_frame_parser():
+    """
+    Tests to make sure that a FrameParser's polling can parse multiple
+    frames.
+    """
+    assert list(
+        poller.FrameParser(
+            poller.SequentialMockPoller(consts.FRAME_PARSER_FRAMES),
+            consts.COMBINE_AXES_DICT,
+        )
+    ) == [
+        {"Button0": 0, "Joystick1": (0, 0)},
+        {"Button0": 1, "Joystick1": (0.5, 0)},
+        {"Button0": 1, "Joystick1": (1, 1)},
+    ]


### PR DESCRIPTION
It is likely that we will need to combine the results of various
attributes of frames into single units. For example, joystick axes
are two units, but refer to the same joystick, and it might be
important to register a change in either axis as a change to the
entire joystick. This class does that.

This solves Issue #8.