### PR TITLE
Add ambiguity handling to translator

### DIFF
--- a/tests/consts.py
+++ b/tests/consts.py
@@ -24,16 +24,16 @@ COMBINE_AXES_DICT = {"Joystick1": ("Axis1", "Axis2")}
 
 CALIBRATION_DICT = {
     "Axis1": {
-        0.5: ["ModifierButton", "Button1"],
-        1: ["Button1"],
-        -0.5: ["ModifierButton", "Button2"],
-        -1: ["Button2"],
+        0.5: [["ModifierButton", "Button1"]],
+        1: [["Button1"]],
+        -0.5: [["ModifierButton", "Button2"]],
+        -1: [["Button2"]],
     },
     "Axis2": {
-        0.5: ["ModifierButton", "Button3"],
-        1: ["Button3"],
-        -0.5: ["ModifierButton", "Button4"],
-        -1: ["Button4"],
+        0.5: [["ModifierButton", "Button3"]],
+        1: [["Button3"]],
+        -0.5: [["ModifierButton", "Button4"]],
+        -1: [["Button4"]],
     },
 }
 

--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -6,7 +6,7 @@ from . import consts
 
 
 def test_translator():
-    device = translator.Translator(
+    device = translator.RawTranslator(
         poller.SequentialMockPoller(consts.FRAME_PARSER_FRAMES),
         ["Button1", "Button2", "Button3", "Button4", "ModifierButton"],
         consts.CALIBRATION_DICT,
@@ -16,7 +16,7 @@ def test_translator():
 
 def test_translator_event_gen():
     device = event_gen.EventGenerator(
-        translator.Translator(
+        translator.RawTranslator(
             poller.SequentialMockPoller(consts.FRAME_PARSER_FRAMES),
             ["Button1", "Button2", "Button3", "Button4", "ModifierButton"],
             consts.CALIBRATION_DICT,


### PR DESCRIPTION
Since it is possible for multiple button combinations to correspond
to the same controller state, the Translator needs to be able to
express ambiguity.

This adds a QuasiTranslator, which returns generators of possible
frames whenever polled. It also adds a RawTranslator, which
resolves this ambiguity by picking the first element of every
generator. More intelligent methods for resolving ambiguity will
likely be needed.